### PR TITLE
Add nix run command for VM to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,3 +84,10 @@ nix build .#base.vm
 result/bin/run-nixbsd-base-vm
 # login as root:toor or bestie:toor
 ```
+
+or to just build and try a VM to play with without a local checkout:
+```shell
+nix run 'github:nixos-bsd/nixbsd#extra.vm'
+```
+but see the above warning about substituter trust before accepting the requested substitutor.
+This will put VM state files in the current directory.


### PR DESCRIPTION
It was useful for me to try things with minimal effort. On the other hand the use for others (who don't personally know and trust @artemist) is debatable because of the 30 or so hours to build without trusting the substituter.