### PR TITLE
add virtualisation.rootSize

### DIFF
--- a/modules/virtualisation/qemu-vm.nix
+++ b/modules/virtualisation/qemu-vm.nix
@@ -228,13 +228,13 @@ tem partition but the drive layout is asking for it!" else config.boot.loader.es
 
   freebsdRootPartition = pkgs.callPackage ../../lib/make-partition-image.nix (commonRoot // {
     filesystem = cfg.rootFilesystem;
-    totalSize = "10g";
+    totalSize = cfg.rootSize;
   });
 
   openbsdRootPartition = pkgs.callPackage ../../lib/make-partition-image.nix (commonRoot // {
     filesystem = "ufs";
     ufsVersion = "1";
-    totalSize = "10g";
+    totalSize = cfg.rootSize;
     contents = commonRoot.contents ++ [{
       target = "/dev/MAKEDEV";
       source = getExe pkgs.openbsd.makedev;
@@ -359,6 +359,15 @@ in {
       type = types.str;
       default = if pkgs.stdenv.hostPlatform.isOpenBSD then "ffs" else "ufs";
       description = "The partition kind to use for the image root filesystem.";
+    };
+
+    virtualisation.rootSize = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        The size of the root disk image to generate with lowercase suffix, e.g 'g'.
+        Use null to match the contents precisely.
+      '';
     };
 
     virtualisation.rootDevice = mkOption {


### PR DESCRIPTION
While we're still doing non-netboot VMs this option is useful to expose. I think these changes are all that are needed for it?

extracted from

https://github.com/nixos-bsd/nixbsd/commit/775a067e70e2a90ab1ffe8158ee87eb5b0db8044

https://github.com/nixos-bsd/nixbsd/commit/1b581e1c82306a430d58cc92147cfd031a884793