### PR TITLE
feat: flake-less entrypoint

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -115,11 +115,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742754557,
-        "narHash": "sha256-nGxgiNhA94eSl8jcQwCboJ5Ed132z8yrFdOoT+rf8bE=",
+        "lastModified": 1774383462,
+        "narHash": "sha256-rmrAK/K6l2LTZhDHyJZzOA4Rr/l/ibfCfFLeilgGLpU=",
         "owner": "nixos-bsd",
         "repo": "mini-tmpfiles",
-        "rev": "534ee577692c7092fdcd035f89bc29b663c6f9ca",
+        "rev": "0ca64ae0ede8106dc3f9b4756672bb573cc5dc29",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
             #lixFlake = lix;
             lixFlake = null;
             cppnixFlake = cppnix;
-            mini-tmpfiles-flake = mini-tmpfiles;
+            mini-tmpfiles-overlay = mini-tmpfiles.overlays.default;
           } // (args.specialArgs or { });
         } // lib.optionalAttrs (!args ? system) { system = null; });
 

--- a/modules/misc/nix-overlay.nix
+++ b/modules/misc/nix-overlay.nix
@@ -1,5 +1,13 @@
-{ config, lib, lixFlake ? null, cppnixFlake ? null, mini-tmpfiles-flake ? null, ... }:
-with lib; {
+{
+  config,
+  lib,
+  lixFlake ? null,
+  cppnixFlake ? null,
+  mini-tmpfiles-overlay ? null,
+  ...
+}:
+with lib;
+{
   # TODO: @artemist remove when support is upstream
   # Also remove specialArgs and input changes in flake
   options = {
@@ -37,10 +45,11 @@ with lib; {
   };
 
   config = {
-    nixpkgs.overlays =
-      lib.optional (lixFlake != null && config.nixpkgs.overrideNix) lixFlake.overlays.default
-      ++ lib.optional (cppnixFlake != null && config.nixpkgs.overrideNix) cppnixFlake.overlays.internal
-      ++ lib.optional (mini-tmpfiles-flake != null && config.nixpkgs.overrideMiniTmpfiles) mini-tmpfiles-flake.overlays.default
-      ++ [ (import ../../overlays/pkgs.nix) ];
+    nixpkgs.overlays = let 
+      lixOverlay = lib.optional (lixFlake != null && config.nixpkgs.overrideNix) lixFlake.overlays.default;
+      nixOverlay = lib.optional (cppnixFlake != null && config.nixpkgs.overrideNix) cppnixFlake.overlays.internal or cppnixFlake.overlays.default;
+      tmpFilesOverlay = lib.optional (mini-tmpfiles-overlay != null && config.nixpkgs.overrideMiniTmpfiles) mini-tmpfiles-overlay;
+    in  
+      lixOverlay ++ nixOverlay ++ tmpFilesOverlay ++ [ (import ../../overlays/pkgs.nix) ];
   };
 }

--- a/modules/virtualisation/jails.nix
+++ b/modules/virtualisation/jails.nix
@@ -100,7 +100,7 @@ in
                 merge = loc: defs: (import ../../lib/eval-config.nix {
                   inherit lib;
                   extraArgs = {
-                    inherit (host) lixFlake cppnixFlake mini-tmpfiles-flake;
+                    inherit (host) lixFlake cppnixFlake mini-tmpfiles-overlay;
                   };
                   nixpkgsPath = config.nixpkgs;
                   modules =

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -1,0 +1,72 @@
+let
+# Based on <nixpkgs/nixos> entrypoint for flake-less systems
+# Still using some hard-coded flake references for compatibility issues
+  fromENV =
+    name: default:
+    let
+      value = builtins.getEnv name;
+    in
+    if value == "" then default else value;
+
+  fromDiamond = path: default: if (builtins.tryEval path).success then path else default;
+
+  flakeInfo = builtins.fromJSON (builtins.readFile ../flake.lock);
+  fromFlake =
+    name:
+    let
+      nodeName = flakeInfo.nodes.root.inputs.${name};
+      node = flakeInfo.nodes.${nodeName};
+      inherit (node.locked)
+        lastModified
+        narHash
+        owner
+        repo
+        rev
+        type
+        ;
+    in
+    builtins.fetchTarball {
+      url =
+        flakeInfo.nodes.${nodeName}.locked.url
+          or "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+
+      sha256 = narHash;
+    };
+
+  diamondConfig = fromDiamond <nixbsd-config> <nixos-config>;
+in
+{
+  configuration ? fromENV "NIXBSD_CONFIG" (fromENV "NIXOS_CONFIG" diamondConfig),
+  pkgs ? import <nixpkgs> { },
+  system ? builtins.currentSystem,
+  # This should only be used for special arguments that need to be evaluated when resolving module structure (like in imports).
+  # For everything else, there's _module.args.
+  specialArgs ? { },
+}:
+
+let
+
+  eval = import ../lib/eval-config.nix {
+    inherit system;
+    inherit (pkgs) lib;
+    nixpkgsPath = pkgs.path;
+
+    modules = [ configuration ];
+
+    specialArgs = {
+      #lixFlake = lix;
+      lixFlake = null;
+      cppnixFlake = import (fromFlake "cppnix"); # can be overriden w/ specialArgs
+      mini-tmpfiles-overlay = import "${fromFlake "mini-tmpfiles"}/overlay.nix"; # can be overriden w/ specialArgs
+    }
+    // specialArgs;
+  };
+in
+
+{
+  inherit (eval) pkgs config options;
+
+  system = eval.config.system.build.toplevel;
+
+  # inherit (eval.config.system.build) vm vmWithBootLoader;
+}


### PR DESCRIPTION
This allows one to build a configuration like that : 
(nixos-install/nixos-rebuild compliant)

❯ nix build  -I nixpkgs=XXX -I nixbsd=XXX -I nixbsd-config=./configurations/freebsd-installer -f '<nixbsd/nixos>' config.system.build.toplevel