### PR TITLE
Add bootable ISO image support

### DIFF
--- a/configurations/iso/default.nix
+++ b/configurations/iso/default.nix
@@ -1,0 +1,62 @@
+# NixBSD ISO image configuration
+# Produces a bootable live ISO suitable for installation or recovery.
+#
+# Build with: nix build .#iso.isoImage
+{ config, lib, pkgs, ... }:
+{
+  imports = [
+    ../../modules/installer/cd-dvd/iso-image.nix
+    ../../modules/installer/cd-dvd/iso-live-boot.nix
+  ];
+
+  nixpkgs.hostPlatform = "x86_64-freebsd";
+
+  # ISO image settings
+  isoImage.isoName = "nixbsd-${config.system.nixos.label}.iso";
+  isoImage.volumeID = "NIXBSD_ISO";
+
+  # Boot loader
+  boot.loader.stand-freebsd.enable = true;
+
+  # Root password for the live environment
+  users.users.root.initialPassword = "nixbsd";
+
+  # A regular user for the live environment
+  users.users.nixbsd = {
+    isNormalUser = true;
+    description = "NixBSD Live User";
+    extraGroups = [ "wheel" ];
+    initialPassword = "nixbsd";
+  };
+
+  # Enable SSH for remote access
+  services.sshd.enable = true;
+
+  # Use C.UTF-8 locale which is built into FreeBSD's C library and doesn't
+  # require external locale files to be accessible at login time.
+  i18n.defaultLocale = "C.UTF-8";
+
+  # Networking
+  networking.dhcpcd.wait = "background";
+
+  # Basic packages for an installation/recovery environment
+  environment.systemPackages = with pkgs; [
+    file
+    gitMinimal
+    htop
+    tmux
+    vim
+  ];
+
+  # Include installer tools
+  system.includeInstallerDependencies = true;
+
+  # Enable flakes and nix-command for convenience
+  nix.settings = {
+    trusted-users = [ "@wheel" ];
+    experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,11 @@
           vmClosureInfo = extended.pkgs.closureInfo {
             rootPaths = [ extended.config.system.build.vm.drvPath ];
           };
+          isoClosureInfo = lib.optionalAttrs (extended.config.system.build ? isoImage) (
+            extended.pkgs.closureInfo {
+              rootPaths = [ extended.config.system.build.isoImage.drvPath ];
+            }
+          );
           system = extended.config.system.build.toplevel;
           inherit (extended) pkgs config;
         };
@@ -106,6 +111,9 @@
         }
         // lib.optionalAttrs (attrs.systemImage != null) {
           inherit (attrs) systemImage;
+        }
+        // lib.optionalAttrs (attrs ? isoImage) {
+          inherit (attrs) isoImage;
         }
       ) self.packages.x86_64-linux;
     };

--- a/lib/make-cd9660-image.nix
+++ b/lib/make-cd9660-image.nix
@@ -215,6 +215,25 @@ let
       for f in $(cat ${nixStoreClosurePaths}/store-paths); do
         cp -a $f $root/nix/store
       done
+
+      # FreeBSD's makefs -t cd9660 silently drops some symlinks.
+      # Dereference all symlinks that point within /nix/store/ since all
+      # targets are present in the tree. This avoids the makefs bug.
+      chmod -R u+w $root/nix/store
+
+      # Collect all symlinks first (avoid modifying tree during find traversal)
+      find $root/nix/store -type l > $TMPDIR/symlinks.txt
+
+      while read -r link; do
+        target=$(readlink "$link")
+        if [[ "$target" == /nix/store/* ]]; then
+          resolved="$root$target"
+          if [ -e "$resolved" ]; then
+            rm -f "$link"
+            cp -a "$resolved" "$link"
+          fi
+        fi
+      done < $TMPDIR/symlinks.txt
     ''
     + lib.optionalString storeRegistration ''
       # Also include a manifest of the closures in a format suitable for

--- a/modules/config/i18n-freebsd.nix
+++ b/modules/config/i18n-freebsd.nix
@@ -107,7 +107,7 @@ with lib;
       allLocaleVars = {
         LANG = config.i18n.defaultLocale;
         # These are now hardcoded
-        #PATH_LOCALE = "/run/current-system/sw/share/locale";
+        PATH_LOCALE = "/run/current-system/sw/share/locale";
         #PATH_I18NMODULE = "/run/current-system/sw/lib/i18n";
         MM_CHARSET =
           let
@@ -130,5 +130,11 @@ with lib;
 
       environment.sessionVariables = allLocaleVars;
       init.environment = allLocaleVars;
+
+      # Set PATH_LOCALE in login.conf so locale is available before shell
+      # profile scripts run (bash calls setlocale() at startup).
+      users.classes.default.settings.setenv = "PATH_LOCALE=/run/current-system/sw/share/locale,LANG=${config.i18n.defaultLocale}";
+      users.classes.root.settings.setenv = "PATH_LOCALE=/run/current-system/sw/share/locale,LANG=${config.i18n.defaultLocale}";
+      users.classes.daemon.settings.setenv = "PATH_LOCALE=/run/current-system/sw/share/locale";
     };
 }

--- a/modules/config/update-users-groups.pl
+++ b/modules/config/update-users-groups.pl
@@ -268,6 +268,9 @@ foreach my $u (@{$spec->{users}}) {
     }
 
     $u->{class} = "" unless defined $u->{class}; 
+    $u->{description} = "" unless defined $u->{description};
+    $u->{hashedPassword} = "*" unless defined $u->{hashedPassword};
+    $u->{home} = "/var/empty" unless defined $u->{home};
 
     $usersOut{$name} = $u;
 
@@ -295,6 +298,11 @@ updateFile($uidMapFile, to_json($uidMap, {canonical => 1}));
 updateFile("/etc/master.passwd", \@lines);
 
 # Regenerate /etc/passwd
+# Ensure /etc/shells exists so pwd_mkdb doesn't warn about unknown shells
+if (!$is_dry && !-e "/etc/shells") {
+    my @shells = map { $_->{shell} } grep { defined $_->{shell} && $_->{shell} ne "" } values %usersOut;
+    updateFile("/etc/shells", join("\n", @shells) . "\n");
+}
 system("pwd_mkdb", "-p", "/etc/master.passwd") unless $is_dry;
 
 # Rewrite /etc/subuid & /etc/subgid to include default container mappings

--- a/modules/config/user-class.nix
+++ b/modules/config/user-class.nix
@@ -348,5 +348,9 @@ in
         ${cap_mkdb} /etc/login.conf
       '';
     };
+
+    # Ensure standard FreeBSD classes always exist
+    users.classes.root = { };
+    users.classes.daemon = { };
   };
 }

--- a/modules/installer/cd-dvd/iso-image.nix
+++ b/modules/installer/cd-dvd/iso-image.nix
@@ -1,0 +1,187 @@
+# This module creates a bootable ISO 9660 image for NixBSD.
+# It produces an EFI-bootable ISO with the Nix store embedded directly
+# on the ISO filesystem (uncompressed).
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cfg = config.isoImage;
+
+  espContents = config.boot.loader.espContents;
+  toplevel = config.system.build.toplevel;
+
+  # The espContents has broken relative symlinks for kernel modules.
+  # Create a resolved copy with real files for use on the ISO and EFI image.
+  resolvedEspContents = pkgs.runCommand "esp-resolved" {
+    nativeBuildInputs = [ pkgs.rsync ];
+    # Ensure the kernel closure is available in the sandbox
+    inherit toplevel;
+  } ''
+    mkdir -p $out
+
+    # Copy the ESP contents (preserving broken symlinks initially)
+    cp -a ${espContents}/* $out/ 2>/dev/null || true
+
+    # Make everything writable so we can fix symlinks
+    chmod -R u+w $out
+
+    # Find and fix all broken symlinks by resolving relative targets against /nix/store
+    find $out -type l | while read -r link; do
+      target=$(readlink "$link")
+      if [[ "$target" == ../../* ]] && [ ! -e "$link" ]; then
+        # These symlinks were meant to resolve from /nix/store/<hash>/<subdir>/
+        # Extract the store-relative path (strip leading ../../)
+        store_relative="''${target#../../}"
+        abs_target="/nix/store/$store_relative"
+        if [ -e "$abs_target" ]; then
+          rm "$link"
+          cp "$abs_target" "$link"
+        else
+          echo "WARNING: Cannot resolve symlink $link -> $target (tried $abs_target)"
+          rm "$link"
+        fi
+      elif [ ! -e "$link" ]; then
+        echo "WARNING: Broken symlink $link -> $target"
+        rm "$link"
+      fi
+    done
+  '';
+
+  # Build the EFI boot image (FAT filesystem) for El-Torito booting
+  efiBootImage = pkgs.callPackage ../../../lib/make-partition-image.nix {
+    inherit pkgs lib;
+    label = "EFIBOOT";
+    filesystem = "efi";
+    contents = [
+      {
+        target = "/";
+        source = resolvedEspContents;
+      }
+    ];
+    totalSize = "256m";
+  };
+
+  # The full set of store paths to include on the ISO
+  storeContents = [ config.system.build.toplevel ];
+
+  # Additional files to place on the ISO (outside the Nix store)
+  isoContents =
+    [
+      # EFI boot image must be at a known path on the ISO for El-Torito
+      {
+        source = "${efiBootImage}";
+        target = "/boot/efi.img";
+      }
+      # Boot loader files (lua scripts, defaults, config) on the ISO root
+      # so that loader.efi can find them when it switches currdev to cd0:
+      {
+        source = "${resolvedEspContents}/boot";
+        target = "/boot";
+      }
+      # Kernel and initmd files referenced by the boot config
+      {
+        source = "${resolvedEspContents}/nixos";
+        target = "/nixos";
+      }
+      # Include the toplevel system link for easy reference
+      {
+        source = config.system.build.toplevel;
+        target = "/run/current-system";
+      }
+    ]
+    ++ cfg.contents;
+
+in
+{
+  options = {
+    isoImage = {
+      isoName = mkOption {
+        default = "${config.system.name}.iso";
+        type = types.str;
+        description = ''
+          Name of the generated ISO image file.
+        '';
+      };
+
+      volumeID = mkOption {
+        default = "NIXBSD_ISO";
+        type = types.str;
+        description = ''
+          The volume ID of the ISO image. Limited to 32 characters.
+        '';
+      };
+
+      contents = mkOption {
+        default = [ ];
+        type = types.listOf (
+          types.submodule {
+            options = {
+              source = mkOption { type = types.path; };
+              target = mkOption { type = types.str; };
+            };
+          }
+        );
+        description = ''
+          Additional files/directories to place on the ISO filesystem.
+        '';
+      };
+
+      storeContents = mkOption {
+        default = [ ];
+        type = types.listOf types.package;
+        description = ''
+          Additional store paths whose closures should be included on the ISO.
+        '';
+      };
+
+      compressImage = mkOption {
+        default = false;
+        type = types.bool;
+        description = ''
+          Whether to compress the resulting ISO image with xz.
+        '';
+      };
+
+      includeStoreRegistration = mkOption {
+        default = true;
+        type = types.bool;
+        description = ''
+          Whether to include a Nix path registration file on the ISO,
+          allowing the live system to use `nix-store --load-db` to register paths.
+        '';
+      };
+    };
+  };
+
+  config = {
+    # The ISO image derivation
+    system.build.isoImage = pkgs.callPackage ../../../lib/make-cd9660-image.nix {
+      inherit pkgs lib;
+
+      isoName = cfg.isoName;
+      volumeID = cfg.volumeID;
+      compressImage = cfg.compressImage;
+      inherit (pkgs) zstd;
+
+      # EFI boot configuration
+      efiBootable = true;
+      efiBootImage = "/boot/efi.img";
+
+      # Contents on the ISO filesystem
+      contents = isoContents;
+
+      # Store paths to embed (full closure copied to /nix/store on ISO)
+      storeContents = storeContents ++ cfg.storeContents;
+      storeRegistration = cfg.includeStoreRegistration;
+
+      # We don't use the squashfs/compressed path for now
+      squashfsContents = [ ];
+    };
+  };
+}

--- a/modules/installer/cd-dvd/iso-live-boot.nix
+++ b/modules/installer/cd-dvd/iso-live-boot.nix
@@ -1,0 +1,130 @@
+# This module configures a NixBSD system for live booting from an ISO image.
+# It sets up:
+# - tmpfs as root filesystem
+# - initmd (memory disk) for early boot pivot
+# - CD-ROM mount for accessing the Nix store on the ISO
+# - Read-only Nix store with tmpfs writable overlay
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+with lib;
+
+let
+  cdDevice = "/dev/cd0";
+  cdMountPoint = "/iso";
+
+  # Match the priority used by readOnlyNixStore in nix-store.nix
+  mkVMOverride = lib.mkOverride 10;
+in
+{
+  config = {
+    # Filesystem layout for the live ISO.
+    # Uses mkVMOverride (priority 10) to match readOnlyNixStore's fileSystems.
+    fileSystems = mkVMOverride {
+      "/" = {
+        device = "tmpfs";
+        fsType = "tmpfs";
+        noCheck = true;
+      };
+
+      ${cdMountPoint} = {
+        device = cdDevice;
+        fsType = "cd9660";
+        options = [ "ro" ];
+        noCheck = true;
+      };
+
+      "/nix/.ro-store" = {
+        device = "${cdMountPoint}/nix/store";
+        fsType = "nullfs";
+        options = [ "ro" ];
+        depends = [ cdMountPoint ];
+        noCheck = true;
+      };
+    };
+
+    # Read-only nix store with writable tmpfs overlay
+    readOnlyNixStore = {
+      enable = true;
+      readOnlySource = "/nix/.ro-store";
+      writableTmpfs = true;
+    };
+
+    # Boot from memory disk, pivot to mount /nix/store from CD
+    boot.initmd = {
+      enable = true;
+      pivotFileSystems = [ "/nix/store" ];
+    };
+
+    # Kernel modules needed for CD-ROM and overlay access
+    boot.kernelModules = [ "cd9660" ];
+
+    # Copy kernel to ESP (needed for the EFI boot image on ISO)
+    boot.copyKernelToBoot = true;
+
+    # No writable ESP on a CD
+    system.build.installBootLoader = mkForce "${pkgs.coreutils}/bin/true";
+
+    # Empty fstab - all filesystems are mounted by init0
+    environment.etc."fstab" = mkForce { text = ""; };
+
+    # No-op mountcritlocal since init0 handles all mounts.
+    # The default fails when fstab is empty (FreeBSD xargs quirk).
+    freebsd.rc.services.mountcritlocal.hooks.start_cmd = mkForce ":";
+
+    # Disable devd (needs persistent /var/log)
+    freebsd.rc.conf.devd_enable = mkForce false;
+
+    # Set early_late_divider directly in rc.conf since /etc/defaults/rc.conf
+    # may not be accessible through the filesystem layers at rc parse time.
+    freebsd.rc.conf.early_late_divider = "FILESYSTEMS";
+
+    # Signal init to re-read /etc/ttys after boot completes.
+    # /etc/ttys is created during activation (after init starts), so init
+    # needs a HUP to pick it up and spawn gettys.
+    freebsd.rc.services.iso_getty_init = {
+      description = "Signal init to spawn gettys";
+      rcorderSettings = {
+        REQUIRE = [ "LOGIN" ];
+        KEYWORD = [ "nojail" ];
+      };
+      hooks.start_cmd = ''
+        kill -HUP 1
+      '';
+    };
+    freebsd.rc.conf.iso_getty_init_enable = true;
+
+    # No swap on a live CD
+    swapDevices = mkForce [ ];
+
+    # Create required directories early in activation.
+    system.activationScripts.iso-early-setup = lib.stringAfter [ "stdio" ] ''
+      mkdir -p /etc /var/log /var/run /var/tmp /var/db /var/empty /var/cache
+      mkdir -p /var/spool/lock /var/lib/nixos /var/run/dhcpcd
+      mkdir -p /run/resolvconf
+      mkdir -p /tmp
+      chmod 1777 /tmp /var/tmp
+    '';
+
+    # Ensure /etc is fully populated. setup-etc.pl creates symlinks from
+    # /etc/ -> /etc/static/, but some may not resolve through the
+    # unionfs/nullfs/cd9660 layers. Copy missing files directly.
+    system.activationScripts.iso-etc-fixup = lib.stringAfter [ "etc" ] ''
+      if [ -d /etc/static ]; then
+        cd /etc/static
+        find . -type f -o -type l | while read -r f; do
+          target="/etc/$f"
+          if [ ! -e "$target" ]; then
+            mkdir -p "$(dirname "$target")"
+            cp -a "/etc/static/$f" "$target" 2>/dev/null || true
+          fi
+        done
+        cd /
+      fi
+    '';
+  };
+}

--- a/modules/system/activation/activation-script.nix
+++ b/modules/system/activation/activation-script.nix
@@ -185,6 +185,7 @@ let
           freebsd.fsck_msdosfs
           freebsd.nscd
           freebsd.pwd_mkdb
+          bash
         ];
         openbsd = [
           openbsd.mount

--- a/modules/system/boot/initmd.nix
+++ b/modules/system/boot/initmd.nix
@@ -203,6 +203,9 @@ let
         dup2(fd, 2);
         printf("hello from init0. we did a pivotroot!\n");
         mkdir("/etc", 0755);
+        /* Create empty fstab to prevent FreeBSD init warning */
+        int fstab_fd = open("/etc/fstab", O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (fstab_fd >= 0) close(fstab_fd);
         mkdir("/nix", 0755);
         mkdir("/nix/store", 0755);
         mkdir("/run", 0755);

--- a/modules/system/boot/initmd.nix
+++ b/modules/system/boot/initmd.nix
@@ -191,16 +191,15 @@ let
             fprintf(stderr, "nmount: %s\n", errmsg);
             return 48;
         }
-        int fd = open("/dev/ttyu0", O_RDWR);
+        int fd = open("/dev/console", O_RDWR);
         if (fd < 0) {
-          return 103;
+          fd = open("/dev/null", O_RDWR);
         }
-        if (fd != 0) {
-          return 104;
+        if (fd >= 0) {
+          if (fd != 0) { dup2(fd, 0); close(fd); }
+          dup2(0, 1);
+          dup2(0, 2);
         }
-        //dup2(fd, 0);
-        dup2(fd, 1);
-        dup2(fd, 2);
         printf("hello from init0. we did a pivotroot!\n");
         mkdir("/etc", 0755);
         /* Create empty fstab to prevent FreeBSD init warning */


### PR DESCRIPTION
Implement EFI-bootable live ISO for NixBSD with the following components:

New files:
- configurations/iso/default.nix: ISO configuration with live user, SSH, basic packages
- modules/installer/cd-dvd/iso-image.nix: ISO image builder module (system.build.isoImage)
- modules/installer/cd-dvd/iso-live-boot.nix: Live boot from CD-ROM with tmpfs root, initmd pivot, nullfs/unionfs nix store overlay

Changes to existing modules:
- flake.nix: Add isoClosureInfo output and isoImage to hydraJobs
- lib/make-cd9660-image.nix: Dereference absolute /nix/store symlinks to work around makefs cd9660 silently dropping some symlinks
- modules/config/i18n-freebsd.nix: Enable PATH_LOCALE and set login.conf setenv so locale works before shell profile is sourced
- modules/config/update-users-groups.pl: Fix uninitialized value warnings for description/hashedPassword/home fields; create /etc/shells before pwd_mkdb
- modules/config/user-class.nix: Always define root and daemon login classes
- modules/system/activation/activation-script.nix: Add bash to FreeBSD activation PATH
- modules/system/boot/initmd.nix: Create /etc/fstab in init0 to prevent early warning

Build with: nix build .#packages.x86_64-linux.iso.isoImage
Test with: qemu-system-x86_64 -m 2048 -cdrom result -boot d -bios OVMF.fd -nographic