### PR TITLE
remove cppnix input, update overlay to replace pkgs.nix with pkgs.nixVersions.latest

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,47 +1,6 @@
 {
   "nodes": {
-    "cppnix": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-parts": "flake-parts",
-        "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-23-11": "nixpkgs-23-11",
-        "nixpkgs-regression": "nixpkgs-regression"
-      },
-      "locked": {
-        "lastModified": 1781190364,
-        "narHash": "sha256-uP1AYpXYHdzmuz+a4AcScRIHa1uy7l9ObZovS0OqN70=",
-        "owner": "nixos",
-        "repo": "nix",
-        "rev": "ce9fda43e5cb8d2f6c57c7240d05d10ad0415799",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
     "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
       "locked": {
         "lastModified": 1733328505,
         "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
@@ -53,54 +12,6 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
-      }
-    },
-    "flake-parts": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "cppnix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "git-hooks-nix": {
-      "inputs": {
-        "flake-compat": [
-          "cppnix"
-        ],
-        "gitignore": [
-          "cppnix"
-        ],
-        "nixpkgs": [
-          "cppnix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
       }
     },
     "mini-tmpfiles": {
@@ -136,42 +47,9 @@
         "url": "https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz"
       }
     },
-    "nixpkgs-23-11": {
-      "locked": {
-        "lastModified": 1717159533,
-        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "cppnix": "cppnix",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat",
         "mini-tmpfiles": "mini-tmpfiles",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1783693695,
-        "narHash": "sha256-4eOaoE0Z2OR28W/vdzp1H9Qkl84ajh7tdVsfNwTuG5U=",
-        "rev": "dc29ee8fa098c86053cc8ef25594738f28be5b6b",
+        "lastModified": 1784834273,
+        "narHash": "sha256-ARPrbHm5ReO4qHnxnIut1gGDz68gl2vyzUFTHenThz4=",
+        "rev": "7d4b60cc165478e9d2c87236a1740e09de951ded",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1032146.dc29ee8fa098/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1040699.7d4b60cc1654/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,6 @@
 {
   inputs = {
     nixpkgs.url = "https://channels.nixos.org/nixos-unstable-small/nixexprs.tar.xz";
-    cppnix = {
-      url = "github:nixos/nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     mini-tmpfiles = {
       url = "github:nixos-bsd/mini-tmpfiles";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -21,7 +17,6 @@
     {
       self,
       nixpkgs,
-      cppnix ? null,
       mini-tmpfiles,
       ...
     }:
@@ -77,7 +72,6 @@
             inherit (nixpkgs) lib;
             nixpkgsPath = nixpkgs.outPath;
             specialArgs = {
-              cppnixFlake = cppnix;
               mini-tmpfiles-flake = mini-tmpfiles;
             }
             // (args.specialArgs or { });

--- a/modules/misc/nix-overlay.nix
+++ b/modules/misc/nix-overlay.nix
@@ -1,30 +1,28 @@
 {
   config,
   lib,
-  cppnixFlake ? null,
   mini-tmpfiles-flake ? null,
   ...
 }:
 with lib;
 {
-  # TODO: @artemist remove when support is upstream
-  # Also remove specialArgs and input changes in flake
   options = {
+    # TODO: remove when stable nix >= 2.35
     nixpkgs.overrideNix = mkOption {
       type = types.bool;
       default = true;
       example = false;
       description = ''
-        Overlay nix with a development version of lix.
+        Overlay nix with the latest version of nix.
 
         This only works when building with a flake and `nixpkgs.pkgs` is not set manually.
 
-        The nixbsd flake includes an input for a patched version of lix
-        for FreeBSD. When this option is enabled then the overlay is enabled so that
+        When this option is enabled then the overlay is enabled so that
         packages and options that require a working nix can build.
       '';
     };
     # TODO: @sky1e remove once mini-tmpfiles is a proper package
+    # Also remove specialArgs and input changes in flake
     nixpkgs.overrideMiniTmpfiles = mkOption {
       type = types.bool;
       default = true;
@@ -45,7 +43,9 @@ with lib;
 
   config = {
     nixpkgs.overlays =
-      lib.optional (cppnixFlake != null && config.nixpkgs.overrideNix) cppnixFlake.overlays.internal
+      lib.optionals config.nixpkgs.overrideNix [
+        (_: prev: { nix = prev.nixVersions.latest; })
+      ]
       ++ lib.optional (
         mini-tmpfiles-flake != null && config.nixpkgs.overrideMiniTmpfiles
       ) mini-tmpfiles-flake.overlays.default

--- a/modules/virtualisation/jails.nix
+++ b/modules/virtualisation/jails.nix
@@ -134,7 +134,7 @@ in
                     (import ../../lib/eval-config.nix {
                       inherit lib;
                       extraArgs = {
-                        inherit (host) cppnixFlake mini-tmpfiles-flake;
+                        inherit (host) mini-tmpfiles-flake;
                       };
                       nixpkgsPath = config.nixpkgs;
                       modules =


### PR DESCRIPTION
I think it's okay to do this now that nixVersions.latest has freebsd sandboxing?